### PR TITLE
remove gh-pages directory after publish

### DIFF
--- a/publish-gh-pages.sh
+++ b/publish-gh-pages.sh
@@ -14,7 +14,7 @@ git commit -m "$USER - rebuilding gh-pages $(date)"
 git remote add origin $ORIGIN_URL
 git push --force origin master:gh-pages
 cd $OLD
-
+rm -rf $BUILD_DIR
 
 # Sources:
 # maybe better with subtrees -> https://gist.github.com/cobyism/4730490


### PR DESCRIPTION
Remove gh-pages directory after publishing the pages, because you don't need it anymore