### PR TITLE
Update build-html-docker-inside-docker.sh

### DIFF
--- a/build-html-docker-inside-docker.sh
+++ b/build-html-docker-inside-docker.sh
@@ -1,16 +1,17 @@
+echo start building html
 set -e
 # copy to gh-pages
 BUILD_DIR="gh-pages"
 rm -rf -v $BUILD_DIR # else plantuml diagrams won't be rebuilt
 # do not copy revealjs
 mkdir -p $BUILD_DIR
-cp -r -p -v asciidocs/images $BUILD_DIR/images/
-cp -r -p -v asciidocs/plantuml $BUILD_DIR/plantuml/
-cp -r -p -v asciidocs/themes $BUILD_DIR
 cp -r -p -v asciidocs/docinfo.html $BUILD_DIR
 cp -r -p -v asciidocs/.nojekyll $BUILD_DIR
 cp -r -p -v asciidocs/index.adoc $BUILD_DIR
 cp -r -p -v asciidocs/*.adoc $BUILD_DIR
+for d in $(find ./asciidocs -type d -maxdepth 1 -mindepth 1); do
+  cp -r -p -v asciidocs/${d##*/} $BUILD_DIR/${d##*/}
+done
 #uncomment it when you want to copy the source code into the gh-pages (for including source code into your document)
 #cp -r -p -v src $BUILD_DIR
 
@@ -18,27 +19,54 @@ CURRENT_FOLDER=${PWD}
 echo "pwd -> ${CURRENT_FOLDER}"
 echo "adoc-folder->${CURRENT_FOLDER}/${BUILD_DIR}/*.adoc"
 asciidoctor \
-           -r asciidoctor-diagram \
-           -a icons=font \
-           -a experimental=true \
-           -a source-highlighter=rouge \
-           -a rouge-theme=github \
-           -a rouge-linenums-mode=inline \
-           -a docinfo=shared \
-           -a imagesdir=images \
-           -a toc=left \
-           -a toclevels=2 \
-           -a sectanchors=true \
-           -a sectnums=true \
-           -a favicon=themes/favicon.png \
-           -a sourcedir=src/main/java \
-           -b html5 \
-           "${CURRENT_FOLDER}/${BUILD_DIR}/*.adoc"
+  -r asciidoctor-diagram \
+  -a icons=font \
+  -a experimental=true \
+  -a source-highlighter=rouge \
+  -a rouge-theme=github \
+  -a rouge-linenums-mode=inline \
+  -a docinfo=shared \
+  -a imagesdir=images \
+  -a toc=left \
+  -a toclevels=2 \
+  -a sectanchors=true \
+  -a sectnums=true \
+  -a favicon=themes/favicon.png \
+  -a sourcedir=src/main/java \
+  -b html5 \
+  "${CURRENT_FOLDER}/${BUILD_DIR}/*.adoc"
 rm -rf ./.asciidoctor
-echo Creating html-docs in Docker finished ...
-
-rm -rf -v $BUILD_DIR/*.adoc
 rm -v $BUILD_DIR/docinfo.html
+rm -rf -v $BUILD_DIR/*.adoc
+echo Creating html-docs in asciidocs in Docker finished ...
+
+for d in $(find ${BUILD_DIR}/ -type d -maxdepth 1 -mindepth 1); do
+  echo searching in ${d}
+adoc=$(find ${d} -type f -name "*.adoc")
+if [[ (-n $adoc) ]]
+then
+    BUILD_DIR="${d}"
+    asciidoctor \
+      -r asciidoctor-diagram \
+      -a icons=font \
+      -a experimental=true \
+      -a source-highlighter=rouge \
+      -a rouge-theme=github \
+      -a rouge-linenums-mode=inline \
+      -a docinfo=shared \
+      -a imagesdir=images \
+      -a toc=left \
+      -a toclevels=2 \
+      -a sectanchors=true \
+      -a sectnums=true \
+      -a favicon=themes/favicon.png \
+      -a sourcedir=src/main/java \
+      -b html5 \
+      "${BUILD_DIR}/*.adoc"
+    echo "${d} htmls created"
+    rm -rf -v $BUILD_DIR/*.adoc
+fi
+done
 
 # https://github.com/asciidoctor/docker-asciidoctor
 


### PR DESCRIPTION
For my school Project I updated the build-html-docker-inside-docker.sh so .adoc files inside subdirectory's would also be made to .html so you can sort your files a little because the URL then would be "username.github.io/repo/subdirectory/somePage.html". For example we wanted to differentiate the different classes that work on my project better.
The process of finding the subdirectory is all solved with loops.
The Script only goes one directory level deeper!
The script will only go in the directory and make the .adoc files to .html if a .adoc file is inside.
Also some more echos where made in the script so the user knows what's happening at runtime.